### PR TITLE
Add dashboard summary endpoint

### DIFF
--- a/Controllers/DashboardController.cs
+++ b/Controllers/DashboardController.cs
@@ -1,0 +1,39 @@
+using api.cliente.Interfaces;
+using api.coleta.Controllers;
+using api.dashboard.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace api.dashboard.Controllers
+{
+    [ApiController]
+    [Route("api/dashboard")]
+    public class DashboardController : BaseController
+    {
+        private readonly DashboardService _dashboardService;
+        private readonly IJwtToken _jwtToken;
+        private readonly INotificador _notificador;
+
+        public DashboardController(DashboardService dashboardService, IJwtToken jwtToken, INotificador notificador)
+            : base(notificador)
+        {
+            _dashboardService = dashboardService;
+            _jwtToken = jwtToken;
+            _notificador = notificador;
+        }
+
+        [HttpGet("resumo")]
+        [Authorize]
+        public IActionResult ObterResumo()
+        {
+            var token = ObterIDDoToken();
+            Guid userId = (Guid)_jwtToken.ObterUsuarioIdDoToken(token);
+            if (userId != Guid.Empty)
+            {
+                var resumo = _dashboardService.ObterResumo(userId);
+                return Ok(resumo);
+            }
+            return BadRequest(new { message = "Token inválido ou ID do usuário não encontrado." });
+        }
+    }
+}

--- a/Models/DTOs/DashboardDTO.cs
+++ b/Models/DTOs/DashboardDTO.cs
@@ -1,0 +1,11 @@
+namespace api.dashboard.DTOs
+{
+    public class DashboardResumoDTO
+    {
+        public int Clientes { get; set; }
+        public int Fazendas { get; set; }
+        public int SafrasAtivas { get; set; }
+        public int Talhoes { get; set; }
+        public int Funcionarios { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -19,6 +19,7 @@ using api.cliente.Interfaces;
 using BackAppPromo.Infrastructure.Authentication;
 using api.minionStorage.Services;
 using api.coleta.Services;
+using api.dashboard.Services;
 using AutoMapper;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -135,6 +136,8 @@ builder.Services.AddScoped<GeoJsonService>();
 
 builder.Services.AddScoped<RelatorioRepository>();
 builder.Services.AddScoped<RelatorioService>();
+
+builder.Services.AddScoped<DashboardService>();
 
 
 

--- a/Services/DashboardService.cs
+++ b/Services/DashboardService.cs
@@ -1,0 +1,32 @@
+using api.coleta.Data;
+using api.coleta.Services;
+using api.dashboard.DTOs;
+using AutoMapper;
+
+namespace api.dashboard.Services
+{
+    public class DashboardService : ServiceBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public DashboardService(ApplicationDbContext context, IUnitOfWork unitOfWork, IMapper mapper)
+            : base(unitOfWork, mapper)
+        {
+            _context = context;
+        }
+
+        public DashboardResumoDTO ObterResumo(Guid userId)
+        {
+            var resumo = new DashboardResumoDTO
+            {
+                Clientes = _context.Clientes.Count(c => c.UsuarioID == userId),
+                Fazendas = _context.Fazendas.Count(f => f.UsuarioID == userId),
+                SafrasAtivas = _context.Safras.Count(s => s.UsuarioID == userId && s.DataFim == null),
+                Talhoes = _context.Talhoes.Count(t => t.UsuarioID == userId),
+                Funcionarios = _context.Usuarios.Count(u => u.adminId == userId)
+            };
+
+            return resumo;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `DashboardResumoDTO` for dashboard data
- implement `DashboardService` to aggregate entity counts
- add `DashboardController` with an authenticated `resumo` endpoint
- register `DashboardService` in the service container

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843175944a8832f94e71bf8b3e054ce